### PR TITLE
Add `drawHistogram` option to Shiny app 

### DIFF
--- a/drawFigureRcode/drawContour.R
+++ b/drawFigureRcode/drawContour.R
@@ -2,6 +2,9 @@ output$drawContour<- renderPlotly({
   input$getPlot
   dataTable<-filedata()
   predictPlot<-calculatePredict()
+  ###
+  drawHistogram <- input$drawHist == "Yes"
+  ###
   contcov<-seq(input$covSlider[1],input$covSlider[2],length.out = 21)
   showCont<-ifelse(identical(input$covName,""),input$covariate,input$covName)
   if(!identical(input$strata,"yes")){
@@ -15,29 +18,35 @@ output$drawContour<- renderPlotly({
                                          ifelse(identical(input$CoxorFG,"noComp"),"survival","CIF"),
                                          ' is %{z:.2f}<extra></extra>'))
     fig <- fig %>% layout(title=list(text=ifelse(identical(input$CoxorFG,"noComp"),
-                                         "Contour Plot of the Predicted Survival Probability",
-                         "Contour Plot of the Predicted Cumulative Incidence Function"),
-                         font=list(size=20),
-                         x=0.15),
-                  xaxis=list(title=list(text="Time",
-                                        font=list(size=20)),range=range(predictPlot$time)),
-                  yaxis=list(title=list(text=showCont,
-                                        font=list(size=20)),range=range(contcov)))
+                                                 "Contour Plot of the Predicted Survival Probability",
+                                                 "Contour Plot of the Predicted Cumulative Incidence Function"),
+                                     font=list(size=20),
+                                     x=0.15),
+                          xaxis=list(title=list(text="Time",
+                                                font=list(size=20)),range=range(predictPlot$time)),
+                          yaxis=list(title=list(text=showCont,
+                                                font=list(size=20)),range=range(contcov)))
     histPlot<-plot_ly(y = histData, type = "histogram",hoverinfo='none') 
     histPlot<-histPlot%>%layout(margin=list(l=100))
-   s <- subplot(fig,
-     histPlot %>% layout(xaxis=list(title="Count")),
-     nrows = 1, widths = c(0.8, 0.2),
-     margin = 0.01,
-     shareY = TRUE,
-     titleX=TRUE,
-     titleY=TRUE
-   )
-   
-   s <- s %>% layout(
-     margin = list(t = 50,l=5) # Adjust top margin to ensure enough space for the title
-   )
-   
+
+    if (drawHistogram) {
+      s <- subplot(fig,
+                   histPlot %>% layout(xaxis = list(title = "Count")),
+                   nrows = 1,
+                   widths = c(0.8, 0.2),
+                   margin = 0.01,
+                   shareY = TRUE,
+                   titleX = TRUE,
+                   titleY = TRUE) %>%
+        layout(margin = list(t = 50, l = 5))
+    } else {
+      s <- fig
+    }
+    
+    s <- s %>% layout(
+      margin = list(t = 50,l=5) # Adjust top margin to ensure enough space for the title
+    )
+    
   }else{
     # for now we only have stratified Cox model, no stratified FG model.
     strataList<-unique(dataTable[,input$strataCov])
@@ -50,39 +59,54 @@ output$drawContour<- renderPlotly({
                       colorbar = list(title =list(text=ifelse(identical(input$CoxorFG,"noComp"),                                                                              "Predicted survival probability","Predicted CIF")),
                                       titleside='right'),
                       colorscale=input$colSche,type = "contour",
-                     hovertemplate = paste('At time %{x:.2f} <br>with',showCont,
-                                           'being %{y:.2f},<br>the predicted survival is %{z:.2f}<extra></extra>'))
+                      hovertemplate = paste('At time %{x:.2f} <br>with',showCont,
+                                            'being %{y:.2f},<br>the predicted survival is %{z:.2f}<extra></extra>'))
       temp <- temp %>% layout(title=list(text="Contour Plot of the Predicted Survival Probability",
                                          font = list(size = 20),
                                          x=0.15),
-        xaxis=list(title=list(text="Time",font = list(size = 20)),range=range(predictPlot$time)),
-                            yaxis=list(title=list(text=showCont,
-                                                  font = list(size = 20)),range=range(contcov)))
+                              xaxis=list(title=list(text="Time",font = list(size = 20)),range=range(predictPlot$time)),
+                              yaxis=list(title=list(text=showCont,
+                                                    font = list(size = 20)),range=range(contcov)))
       if(i>1){
         temp<-temp %>% hide_colorbar()
       }
-      plotList[[2*i-1]]<-temp
-      temp2 <- plot_ly(y = histData, type = "histogram",hoverinfo='none',showlegend=FALSE)%>% layout(xaxis=list(title="Count"))
-      temp2 <- temp2 %>% add_annotations(x=0.5,y=1.05,
-                                         yref = "paper",
-                                         xref = "paper",
-                                         text=paste(input$strataName,strataList[i]),
-                                         xanchor = "middle",
-                                         yanchor = "top",
-                                         showarrow=FALSE)
-      plotList[[2*i]]<-temp2
+      
+      if (drawHistogram) {
+        plotList[[2*i - 1]] <- temp
+        temp2 <- plot_ly(y = histData, type = "histogram",hoverinfo='none',showlegend=FALSE)%>% layout(xaxis=list(title="Count"))
+        temp2 <- temp2 %>% add_annotations(x=0.5,y=1.05,
+                                           yref = "paper",
+                                           xref = "paper",
+                                           text=paste(input$strataName,strataList[i]),
+                                           xanchor = "middle",
+                                           yanchor = "top",
+                                           showarrow=FALSE)
+        plotList[[2*i]] <- temp2
+      } else {
+        plotList[[i]] <- temp
+      }
     }
-    s <- subplot(plotList,
-                 nrows = length(strataList), 
-                 #ncol=2,
-                 widths = c(0.8, 0.2),
-                 margin=c(0,0.01,0.02,0),
-                 shareX=TRUE,
-                 shareY=TRUE,titleX = TRUE,titleY = TRUE)
+    
+    if (drawHistogram) {
+      s <- subplot(plotList,
+                   nrows = length(strataList),
+                   widths = c(0.8, 0.2),
+                   margin = c(0, 0.01, 0.02, 0),
+                   shareX = TRUE,
+                   shareY = TRUE,
+                   titleX = TRUE,
+                   titleY = TRUE)
+    } else {
+      s <- subplot(plotList,
+                   nrows = length(strataList),
+                   margin = c(0.01, 0.01, 0.02, 0),
+                   shareY = TRUE,
+                   titleX = TRUE,
+                   titleY = TRUE)
+    }
     s<-s%>%layout(height=450*length(strataList),
-                     margin = list(t = 50,l=5) # Adjust top margin to ensure enough space for the title
-                   )
+                  margin = list(t = 50,l=5) # Adjust top margin to ensure enough space for the title
+    )
   }
   s
 })
- 

--- a/ui.R
+++ b/ui.R
@@ -77,7 +77,10 @@ shinyUI(
                           "Yes, I do." = "Yes"),
                      selected="No"),
         
- 
+        radioButtons("drawHist", "Do you want to include a histogram?",
+                     list("Yes" = "Yes", "No" = "No"),
+                     selected = "Yes"),
+        
         
         # radioButtons("CI3D", "Do you want to show 95% CI for predicted survival in 3D contour plot?(only for Cox model)",
         #              list("No, I don't." = "No",


### PR DESCRIPTION
### Summary
- Added a `drawHistogram` selection option to the Shiny app interface (via `radioButtons`).
- Modified `drawContour.R` to accommodate user input from the Shiny app (`drawHist` value) for flexible plotting.
- Ensured that users can now interactively choose whether to include a histogram in the plot.

### Motivation
To improve user experience and consistency, the Shiny app interface now allows users to choose whether to include a histogram interactively.

### Notes
- The default selection remains "Yes" (histogram included) to maintain consistency with the R function default (`drawHistogram = TRUE`).
- Updated `drawContour.R` to ensure correct behavior depending on the user's selection.
- Changes tested in Shiny app to confirm correct functionality.

Thank you for considering my contribution! 
